### PR TITLE
ajout du clip de BAD APPLE

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,18 @@
+import asyncio
+import json
 from pydantic.dataclasses import dataclass
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List
-from dataclasses import asdict  # Pour convertir la grille en JSON
+from dataclasses import asdict
+from dataclasses import asdict, replace
 
 from repositories import Repositories
 from models import Grid
 from services import Services
 
-
 repositories = Repositories()
 services = Services(repositories)
-
 app = FastAPI()
 
 app.add_middleware(
@@ -21,46 +22,54 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+is_playing = False          #variable de l'etat de la vidéo
+saved_grid_state = None     #save de l'etat de la grille avant le lancement de la vidéo
+
+# Chargement du dataset
+try:
+    with open("data.json", "r") as f:
+        BAD_APPLE_DATA = json.load(f)
+except Exception as e:
+    BAD_APPLE_DATA = []
+    print(f"Dataset non chargé : {e}")
+
 active_clients: List[WebSocket] = []
+
 
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     await websocket.accept()
     active_clients.append(websocket)
-
     grid_service = services.grid()
-
     player_id = grid_service.add_player()
-
     try:
-        # Send the updated grid (including the new player) to everyone
         await broadcast_grid()
-        
         while True:
             await websocket.receive_text()
-            
     except WebSocketDisconnect:
-        active_clients.remove(websocket)
-
+        if websocket in active_clients:
+            active_clients.remove(websocket)
         grid_service.remove_player(player_id)
         await broadcast_grid()
 
 async def broadcast_grid():
     grid = repositories.grid_repository.grid()
     grid_dict = asdict(grid)
-    for client in active_clients:
-        await client.send_json(grid_dict)
+    for client in list(active_clients):
+        try:
+            await client.send_json(grid_dict)
+        except:
+            if client in active_clients:
+                active_clients.remove(client)
 
-@app.get("/grid")
-async def read_grid() -> Grid:
-    grid = repositories.grid_repository.grid()
-    return grid
+
 
 @dataclass
 class UpdateBody:
     caption: str
-    color : str
-    size: int
+    color: str
+    size: int = 10
 
 @app.post("/cell/{cell_index}")
 async def update_cell(cell_index: int, body: UpdateBody):
@@ -68,13 +77,79 @@ async def update_cell(cell_index: int, body: UpdateBody):
     if 0 <= cell_index < len(grid.cells):
         grid.cells[cell_index].caption = body.caption
         grid.cells[cell_index].color = body.color
-        
         await broadcast_grid()
-        
     return grid
+
+
+@app.post("/play-bad-apple")
+async def play_bad_apple():
+    global is_playing, saved_grid_state
+    
+    if is_playing or not BAD_APPLE_DATA:
+        return {"error": "Impossible de lancer"}
+    
+    grid = repositories.grid_repository.grid()
+    
+    #copie de l'état actuel de la Grid avant le lancement de la video
+    saved_grid_state = {
+        "width": grid.width,
+        "height": grid.height,
+        "cells": [replace(c) for c in grid.cells] 
+    }
+    
+    is_playing = True #lancement
+    CellClass = type(grid.cells[0])
+    
+    # Détection de la taille du dataset
+    first_frame = BAD_APPLE_DATA[0]
+    new_height = len(first_frame) # nombre de liste dans la premiere liste
+    new_width = len(first_frame[0])
+    
+    grid.width = new_width
+    grid.height = new_height
+    grid.cells = [CellClass(caption="", color="#ffffff") for _ in range(grid.width * grid.height)]
+    
+    await broadcast_grid()
+    await asyncio.sleep(0.5)
+
+    for frame in BAD_APPLE_DATA:
+        if not is_playing:
+            break
+        for r_idx, row in enumerate(frame):
+            for c_idx, value in enumerate(row):
+                idx = r_idx * new_width + c_idx
+                if idx < len(grid.cells):
+                    grid.cells[idx].color = "#000000" if value == 1 else "#ffffff"
+        await broadcast_grid()
+        await asyncio.sleep(0.04)
+    
+    is_playing = False
+    return {"status": "Terminé"}
 
 @app.post("/reset")
 async def reset_grid():
-    grid = services.grid().reset()
+    global is_playing, saved_grid_state
+    is_playing = False # Arrête le clip si il tourne
+    
+    grid = repositories.grid_repository.grid()
+    
+    # --- RESTAURATION ---
+    if saved_grid_state:
+        grid.width = saved_grid_state["width"]
+        grid.height = saved_grid_state["height"]
+        grid.cells = saved_grid_state["cells"]
+        saved_grid_state = None # On vide la sauvegarde après l'avoir utilisée
+    else:
+        # Si aucune sauvegarde, on fait un reset standard
+        services.grid().reset()
+        grid.width = 10
+        grid.height = 10
+        CellClass = type(grid.cells[0])
+        grid.cells = [CellClass(caption="", color="transparent") for _ in range(100)]
+    
     await broadcast_grid()
     return grid
+
+@app.post("/stop-bad-apple")
+async def stop_bad_apple():
+    return await reset_grid()

--- a/backend/main.py
+++ b/backend/main.py
@@ -56,12 +56,15 @@ async def websocket_endpoint(websocket: WebSocket):
 async def broadcast_grid():
     grid = repositories.grid_repository.grid()
     grid_dict = asdict(grid)
-    for client in list(active_clients):
+    
+    async def send_to_client(client):
         try:
             await client.send_json(grid_dict)
         except:
             if client in active_clients:
                 active_clients.remove(client)
+    
+    await asyncio.gather(*[send_to_client(client) for client in list(active_clients)], return_exceptions=True)
 
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -149,7 +149,3 @@ async def reset_grid():
     
     await broadcast_grid()
     return grid
-
-@app.post("/stop-bad-apple")
-async def stop_bad_apple():
-    return await reset_grid()

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,94 +5,99 @@ import type { components } from "./backend-schema";
 type UpdateCellBody = components["schemas"]["UpdateBody"];
 type Grid = components["schemas"]["Grid"];
 
-async function resetGrid() {
-    await fetch("http://localhost:22222/reset", {
-        method: "POST",
-    });
-}
-
-async function handleUpdateCell(
-  cellIndex: number,
-  color: string
-) {
-  const body: UpdateCellBody = {
-    caption: "",
-    color: color,
-  };
-  await fetch(`http://localhost:22222/cell/${cellIndex}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify(body),
-  });
-}
-
 function App() {
   const [grid, setGrid] = useState<Grid | null>(null);
-  const [color, setColor] = useState("#00ffff");
+  const [color, setColor] = useState("#b2e27b");
 
+  // Connexion WebSocket
   useEffect(() => {
     const ws = new WebSocket("ws://localhost:22222/ws");
-
-    ws.onopen = () => {
-      console.log("WebSocket connected");
-    };
-
-    ws.onmessage = (event) => {
-      const gridData: Grid = JSON.parse(event.data);
-      setGrid(gridData);
-    };
-
-    ws.onerror = (error) => {
-      console.error("WebSocket error:", error);
-    };
-
-    ws.onclose = () => {
-      console.log("WebSocket disconnected");
-    };
-
-    return () => {
-      ws.close();
-    };
+    ws.onmessage = (event) => setGrid(JSON.parse(event.data));
+    return () => ws.close();
   }, []);
+
+  // API Calls
+  const resetGrid = () => fetch("http://localhost:22222/reset", { method: "POST" });
+  const startBadApple = () => fetch("http://localhost:22222/play-bad-apple", { method: "POST" });
+  const stopBadApple = () => fetch("http://localhost:22222/stop-bad-apple", { method: "POST" });
+
+  const handleUpdateCell = async (cellIndex: number, cellColor: string) => {
+    const body: UpdateCellBody = { caption: "", color: cellColor };
+    await fetch(`http://localhost:22222/cell/${cellIndex}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  };
+
+  // Adaptation dynamique de la taille des cases
+  const isVideoMode = grid && grid.width > 20;
+  const cellSize = isVideoMode ? "15px" : "50px";
 
   return (
     <div className="container">
-      <h4>The Grid</h4>
-      <input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+      <h4>The Grid - Bad Apple Edition</h4>
 
-        <input
-            type="button"
-            value="Reset"
-            onClick={() => resetGrid()}
-        />
+      <div className="controls" style={{ marginBottom: "20px" }}>
+        <input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+        <button onClick={resetGrid}>Reset</button>
+
+        <button
+          onClick={startBadApple}
+          style={{ marginLeft: "10px", background: "#2ecc71", color: "white", border: "none", padding: "5px 10px", borderRadius: "4px", cursor: "pointer" }}
+        >
+          ▶ PLAY
+        </button>
+
+        <button
+          onClick={stopBadApple}
+          style={{ marginLeft: "5px", background: "#e74c3c", color: "white", border: "none", padding: "5px 10px", borderRadius: "4px", cursor: "pointer" }}
+        >
+          🛑 OFF
+        </button>
+      </div>
 
       {grid && (
         <>
-          {/* Affichage clair du nombre de cases */}
-          <p className="case-count">
-            Nombre de cases : {grid.width * grid.height}
-          </p>
-
+          <p>Taille de la grille : {grid.width}x{grid.height}</p>
           <div
             className="world-grid"
             style={{
               display: "grid",
-              gridTemplateColumns: `repeat(${grid.width}, 50px)`,
-              gridTemplateRows: `repeat(${grid.height}, 50px)`,
+              gridTemplateColumns: `repeat(${grid.width}, ${cellSize})`,
+              gap: "0px",
+              background: "#ffffff",
+              padding: "8px",
+              borderRadius: "8px",
+              margin: "0 auto",
+              width: "fit-content",
+              boxSizing: "border-box"
             }}
           >
-            {grid.cells.map((cell, cellIndex) => (
+            {grid.cells.map((cell, idx) => (
               <div
-                key={cellIndex}
+                key={idx}
                 className="cell"
-                onClick={() => handleUpdateCell(cellIndex, color)}
+                onClick={() => handleUpdateCell(idx, color)}
                 style={{
+                  width: cellSize,
+                  height: cellSize,
+                  minWidth: cellSize,
+                  minHeight: cellSize,
+                  maxWidth: cellSize,
+                  maxHeight: cellSize,
                   backgroundColor: cell.color ?? "transparent",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: "10px",
+                  boxSizing: "border-box",
+                  border: "0.1px solid #222",
+                  padding: "0"
                 }}
               >
-                {cell.caption ?? ""}
+                {!isVideoMode && cell.caption}
               </div>
             ))}
           </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,6 @@ function App() {
   // API Calls
   const resetGrid = () => fetch("http://localhost:22222/reset", { method: "POST" });
   const startBadApple = () => fetch("http://localhost:22222/play-bad-apple", { method: "POST" });
-  const stopBadApple = () => fetch("http://localhost:22222/stop-bad-apple", { method: "POST" });
 
   const handleUpdateCell = async (cellIndex: number, cellColor: string) => {
     const body: UpdateCellBody = { caption: "", color: cellColor };
@@ -50,7 +49,7 @@ function App() {
         </button>
 
         <button
-          onClick={stopBadApple}
+          onClick={resetGrid}
           style={{ marginLeft: "5px", background: "#e74c3c", color: "white", border: "none", padding: "5px 10px", borderRadius: "4px", cursor: "pointer" }}
         >
           🛑 OFF


### PR DESCRIPTION
<img width="567" height="612" alt="image" src="https://github.com/user-attachments/assets/a52d43c0-bb4d-4574-88ee-fa56aa810968" />


Système de sauvegarde d'état : Ajout d'une variable globale saved_grid_state qui capture la configuration de la grille (dimensions et couleurs) avant le lancement du clip.

Nouvelle route /play-bad-apple :

Adapte dynamiquement la taille de la grille aux dimensions du dataset (36x28).

Diffuse les frames en temps réel via WebSocket avec un intervalle de 0.04s (~25 FPS).

Utilise un flag is_playing pour contrôler l'exécution.

Optimisation de la route /reset :

Mode Restauration : Si un clip était en cours ou s'est terminé, le bouton reset restaure la grille telle qu'elle était avant le clip.

Mode Clear : Si aucune sauvegarde n'existe, effectue un reset standard (grille vide 10x10).

Frontend (React)
Ajout d'une interface de contrôle avec deux boutons :

PLAY : Déclenche l'animation.

STOP / RESET : Interrompt le clip et restaure instantanément l'état précédent de la grille.

Adaptation dynamique : Le composant React recalcule automatiquement l'affichage (colonnes/lignes) en fonction des données reçues par le serveur.